### PR TITLE
Fix warnings in newer puppet versions

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,10 +20,10 @@ class keymaster::params {
   $group             = 'puppet'
 
   case $::osfamily {
-    Debian:{
+    'Debian':{
       # Do nothing
     }
-    RedHat:{
+    'RedHat':{
       # Do nothing
     }
     default:{


### PR DESCRIPTION
Without this change, I get "The keymaster Puppet module does not support Debian family of operating systems"
