### PR TITLE
Fix error in newer puppet server

### DIFF
--- a/manifests/openssh/key.pp
+++ b/manifests/openssh/key.pp
@@ -48,6 +48,7 @@ define keymaster::openssh::key (
 
   # generate exported resources for the ssh client host to realize
   @@keymaster::openssh::key::deploy { $name:
+    user     => $name,
     ensure   => $ensure,
     filename => $real_filename,
     tag      => $clean_tag,
@@ -55,6 +56,7 @@ define keymaster::openssh::key (
 
   # generate exported resources for the ssh server host to realize
   @@keymaster::openssh::key::authorized_key { $name:
+    user     => $name,
     ensure  => $ensure,
     options => $options,
     tag     => $clean_tag,


### PR DESCRIPTION
This fixes https://github.com/Aethylred/puppet-keymaster/issues/7, 
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Keymaster::Openssh::Key::Deploy[testuser]: expects a value for parameter 'user' on node server.example.com.